### PR TITLE
Add ability to set Before/After hooks on Setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     docker:
       - image: lab259/go-circleci:1.12
+      - image: circleci/postgres:alpine
     steps:
       - checkout
       - restore_cache:

--- a/testing/rscsrvtest/rscsrvtest_test.go
+++ b/testing/rscsrvtest/rscsrvtest_test.go
@@ -1,0 +1,11 @@
+package rscsrvtest_test
+
+import (
+	"testing"
+
+	"github.com/lab259/athena/testing/ginkgotest"
+)
+
+func TestRscsrvTestService(t *testing.T) {
+	ginkgotest.Init("athena/testing/rscsrvtest Test Suite", t)
+}

--- a/testing/rscsrvtest/setup.go
+++ b/testing/rscsrvtest/setup.go
@@ -6,14 +6,69 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func Setup(services ...rscsrv.Service) {
+type Setupper interface {
+	Setup(...rscsrv.Service)
+	Before(func()) Setupper
+	After(func()) Setupper
+}
+
+type starter struct {
+	offset int
+	before []func()
+	after  []func()
+}
+
+func (s *starter) Before(fn func()) Setupper {
+	if s.before == nil {
+		s.before = make([]func(), 0, 5)
+	}
+	s.before = append(s.before, fn)
+	return s
+}
+
+func (s *starter) After(fn func()) Setupper {
+	if s.after == nil {
+		s.after = make([]func(), 0, 5)
+	}
+	s.after = append(s.after, fn)
+	return s
+}
+
+func (s *starter) Setup(services ...rscsrv.Service) {
 	serviceStarter := rscsrv.NewServiceStarter(&rscsrv.NopStarterReporter{}, services...)
 
 	ginkgo.BeforeEach(func() {
-		gomega.ExpectWithOffset(1, serviceStarter.Start()).To(gomega.Succeed())
+		gomega.ExpectWithOffset(s.offset+1, serviceStarter.Start()).To(gomega.Succeed())
+
+		for _, beforeFn := range s.before {
+			beforeFn()
+		}
 	})
 
 	ginkgo.AfterEach(func() {
-		gomega.ExpectWithOffset(1, serviceStarter.Stop(false)).To(gomega.Succeed())
+		for _, afterFn := range s.after {
+			afterFn()
+		}
+
+		gomega.ExpectWithOffset(s.offset+1, serviceStarter.Stop(false)).To(gomega.Succeed())
 	})
+}
+
+func Setup(services ...rscsrv.Service) {
+	s := starter{
+		offset: 1,
+	}
+	s.Setup(services...)
+}
+
+func Before(fn func()) Setupper {
+	s := new(starter)
+	s.before = []func(){fn}
+	return s
+}
+
+func After(fn func()) Setupper {
+	s := new(starter)
+	s.after = []func(){fn}
+	return s
 }

--- a/testing/rscsrvtest/setup_test.go
+++ b/testing/rscsrvtest/setup_test.go
@@ -1,0 +1,59 @@
+package rscsrvtest_test
+
+import (
+	"time"
+
+	"github.com/lab259/athena/testing/rscsrvtest"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type clockService struct {
+	startedAt time.Time
+	stoppedAt time.Time
+}
+
+func (s *clockService) Name() string {
+	panic("not implemented")
+}
+
+func (s *clockService) Restart() error {
+	if err := s.Stop(); err != nil {
+		return err
+	}
+	return s.Start()
+}
+
+func (s *clockService) Start() error {
+	s.startedAt = time.Now()
+	time.Sleep(time.Millisecond)
+	return nil
+}
+
+func (s *clockService) Stop() error {
+	s.stoppedAt = time.Now()
+	time.Sleep(time.Millisecond)
+	return nil
+}
+
+var _ = Describe("PsqlTestService", func() {
+	var serv clockService
+	var beforeCalled time.Time
+	var afterCalled time.Time
+
+	rscsrvtest.Before(func() {
+		beforeCalled = time.Now()
+		time.Sleep(time.Millisecond)
+	}).After(func() {
+		afterCalled = time.Now()
+		time.Sleep(time.Millisecond)
+	}).Setup(&serv)
+
+	It("should run before hook after services are started", func() {
+		Expect(beforeCalled).To(BeTemporally(">", serv.startedAt))
+	})
+
+	It("should run after hook before services are stopped", func() {
+		Expect(afterCalled).To(BeTemporally("<", serv.stoppedAt))
+	})
+})

--- a/testing/rscsrvtest/setup_test.go
+++ b/testing/rscsrvtest/setup_test.go
@@ -36,7 +36,7 @@ func (s *clockService) Stop() error {
 	return nil
 }
 
-var _ = Describe("PsqlTestService", func() {
+var _ = Describe("ClockServiceTest", func() {
 	var serv clockService
 	var beforeCalled time.Time
 	var afterCalled time.Time


### PR DESCRIPTION
Useful for running functions after Services are started or before they are stopped.