### PR TITLE
Add ability to bootstrap commands for CLI

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -21,7 +21,7 @@ type CLIOptions struct {
 	BindAddress *string
 	Wait        *int
 	Hostname    *string
-	isDryRun    *bool
+	IsDryRun    *bool
 }
 
 type cliBuilder struct {
@@ -120,12 +120,12 @@ func (b *cliBuilder) Build() (*cli.Cli, *CLIOptions) {
 			EnvVar: "HOSTNAME",
 		})
 
-		options.isDryRun = b.cli.BoolOpt("d dry-run", false, "Loads the configuration and check if the dependencies are working (such as database connections)")
+		options.IsDryRun = b.cli.BoolOpt("d dry-run", false, "Loads the configuration and check if the dependencies are working (such as database connections)")
 
 		b.cli.Before = func() {
 			os.Setenv("HOSTNAME", *options.Hostname)
 
-			if *options.isDryRun {
+			if *options.IsDryRun {
 				rlog.Trace(1, "This is a dry run!")
 			}
 
@@ -147,7 +147,7 @@ func (b *cliBuilder) Build() (*cli.Cli, *CLIOptions) {
 				}
 			}
 
-			if *options.isDryRun {
+			if *options.IsDryRun {
 				if b.serviceStarter != nil {
 					err := b.serviceStarter.Stop(false)
 					if err != nil {
@@ -156,7 +156,7 @@ func (b *cliBuilder) Build() (*cli.Cli, *CLIOptions) {
 					}
 				}
 
-				if *options.isDryRun {
+				if *options.IsDryRun {
 					rlog.Trace(1, "Everything looks fine!")
 				}
 				os.Exit(0)

--- a/cli.go
+++ b/cli.go
@@ -14,6 +14,10 @@ import (
 )
 
 type CLIOptions struct {
+	Version     string
+	Build       string
+	Environment string
+
 	BindAddress *string
 	Wait        *int
 	Hostname    *string
@@ -29,6 +33,7 @@ type cliBuilder struct {
 	bindAddress    string
 	hostname       string
 	serviceStarter rscsrv.ServiceStarter
+	simple         bool
 }
 
 func NewCLI(name, description string) *cliBuilder {
@@ -73,31 +78,18 @@ func (b *cliBuilder) Hostname(hostname string) *cliBuilder {
 	return b
 }
 
+// Simple will disable all flags and the bootstrap Before.
+func (b *cliBuilder) Simple() *cliBuilder {
+	b.simple = true
+	return b
+}
+
 func (b *cliBuilder) Build() (*cli.Cli, *CLIOptions) {
 	var options CLIOptions
 
-	options.BindAddress = b.cli.String(cli.StringOpt{
-		Name:   "B bind-address",
-		Value:  b.bindAddress,
-		Desc:   "The bind address will be used on the HTTP server",
-		EnvVar: "BIND_ADDR",
-	})
-
-	options.Wait = b.cli.Int(cli.IntOpt{
-		Name:   "w wait",
-		Value:  b.wait,
-		Desc:   "Delay in seconds before the initialization",
-		EnvVar: "WAIT",
-	})
-
-	options.Hostname = b.cli.String(cli.StringOpt{
-		Name:   "H hostname",
-		Value:  b.hostname,
-		Desc:   "The name of the station running the app instance",
-		EnvVar: "HOSTNAME",
-	})
-
-	options.isDryRun = b.cli.BoolOpt("d dry-run", false, "Loads the configuration and check if the dependencies are working (such as database connections)")
+	options.Version = b.version
+	options.Build = b.build
+	options.Environment = b.env
 
 	var version strings.Builder
 	version.WriteString(fmt.Sprintf("Version: %s", b.version))
@@ -106,44 +98,69 @@ func (b *cliBuilder) Build() (*cli.Cli, *CLIOptions) {
 	}
 	b.cli.Version("v version", version.String())
 
-	b.cli.Before = func() {
-		os.Setenv("HOSTNAME", *options.Hostname)
+	if !b.simple {
+		options.BindAddress = b.cli.String(cli.StringOpt{
+			Name:   "B bind-address",
+			Value:  b.bindAddress,
+			Desc:   "The bind address will be used on the HTTP server",
+			EnvVar: "BIND_ADDR",
+		})
 
-		if *options.isDryRun {
-			rlog.Trace(1, "This is a dry run!")
-		}
+		options.Wait = b.cli.Int(cli.IntOpt{
+			Name:   "w wait",
+			Value:  b.wait,
+			Desc:   "Delay in seconds before the initialization",
+			EnvVar: "WAIT",
+		})
 
-		rlog.Infof("Version: %s (%s)", b.version, b.build)
-		rlog.Infof("Environment: %s", b.env)
+		options.Hostname = b.cli.String(cli.StringOpt{
+			Name:   "H hostname",
+			Value:  b.hostname,
+			Desc:   "The name of the station running the app instance",
+			EnvVar: "HOSTNAME",
+		})
 
-		if *options.Wait > 0 {
-			rlog.Infof("  Waiting %d seconds before continue ...", *options.Wait)
-			time.Sleep(time.Duration(*options.Wait) * time.Second)
-			rlog.Info(fmt.Sprintf("    > Waiting %s", "DONE"))
-		}
+		options.isDryRun = b.cli.BoolOpt("d dry-run", false, "Loads the configuration and check if the dependencies are working (such as database connections)")
 
-		if b.serviceStarter != nil {
-			err := b.serviceStarter.Start()
-			if err != nil {
-				b.serviceStarter.Stop(true)
-				rlog.Critical(err)
-				os.Exit(2)
+		b.cli.Before = func() {
+			os.Setenv("HOSTNAME", *options.Hostname)
+
+			if *options.isDryRun {
+				rlog.Trace(1, "This is a dry run!")
 			}
-		}
 
-		if *options.isDryRun {
+			rlog.Infof("Version: %s (%s)", b.version, b.build)
+			rlog.Infof("Environment: %s", b.env)
+
+			if *options.Wait > 0 {
+				rlog.Infof("  Waiting %d seconds before continue ...", *options.Wait)
+				time.Sleep(time.Duration(*options.Wait) * time.Second)
+				rlog.Info(fmt.Sprintf("    > Waiting %s", "DONE"))
+			}
+
 			if b.serviceStarter != nil {
-				err := b.serviceStarter.Stop(false)
+				err := b.serviceStarter.Start()
 				if err != nil {
+					b.serviceStarter.Stop(true)
 					rlog.Critical(err)
 					os.Exit(2)
 				}
 			}
 
 			if *options.isDryRun {
-				rlog.Trace(1, "Everything looks fine!")
+				if b.serviceStarter != nil {
+					err := b.serviceStarter.Stop(false)
+					if err != nil {
+						rlog.Critical(err)
+						os.Exit(2)
+					}
+				}
+
+				if *options.isDryRun {
+					rlog.Trace(1, "Everything looks fine!")
+				}
+				os.Exit(0)
 			}
-			os.Exit(0)
 		}
 	}
 

--- a/cmd/athena/make/mgomodel.go
+++ b/cmd/athena/make/mgomodel.go
@@ -6,14 +6,12 @@ import (
 	"path"
 	"path/filepath"
 
-	templates_mongo "github.com/lab259/athena/cmd/athena/make/templates/mongo"
-
-	"github.com/lab259/athena/cmd/athena/util/template"
-
 	"github.com/iancoleman/strcase"
 	cli "github.com/jawher/mow.cli"
 	"github.com/jinzhu/inflection"
+	templates_mongo "github.com/lab259/athena/cmd/athena/make/templates/mongo"
 	"github.com/lab259/athena/cmd/athena/util"
+	"github.com/lab259/athena/cmd/athena/util/template"
 	"github.com/lab259/athena/config"
 )
 

--- a/cmd/athena/make/templates/psql/create_service.go
+++ b/cmd/athena/make/templates/psql/create_service.go
@@ -35,7 +35,7 @@ func Create(ctx context.Context, input *CreateInput) (*CreateOutput, error) {
 
 	db, err := psqlrscsrv.DefaultPsqlService.DB()
 	if err != nil {
-		return nil, errors.Wrap(err, errors.Code("db-available"), errors.Module("{{.Table}}_service"))
+		return nil, errors.Wrap(err, errors.Code("db-not-available"), errors.Module("{{.Table}}_service"))
 	}
 
 	store := models.New{{.Model}}Store(db)

--- a/cmd/athena/make/templates/psql/delete_service.go
+++ b/cmd/athena/make/templates/psql/delete_service.go
@@ -32,7 +32,7 @@ func Delete(ctx context.Context, input *DeleteInput) (*DeleteOutput, error) {
 
 	db, err := psqlrscsrv.DefaultPsqlService.DB()
 	if err != nil {
-		return nil, errors.Wrap(err, errors.Code("db-available"), errors.Module("{{.Table}}_service"))
+		return nil, errors.Wrap(err, errors.Code("db-not-available"), errors.Module("{{.Table}}_service"))
 	}
 
 	store := models.New{{.Model}}Store(db)

--- a/cmd/athena/make/templates/psql/delete_service.go
+++ b/cmd/athena/make/templates/psql/delete_service.go
@@ -15,7 +15,7 @@ import (
 
 // DeleteInput holds input information for Delete service
 type DeleteInput struct {
-	{{.Model}} *models.{{.Model}} `+"`"+`validate:"required"`+"`"+`
+	{{.Model}} *models.{{.Model}} `+"`"+`validate:"structonly,required"`+"`"+`
 }
 
 // DeleteOutput holds the output information from Delete service

--- a/cmd/athena/make/templates/psql/list_service.go
+++ b/cmd/athena/make/templates/psql/list_service.go
@@ -31,7 +31,7 @@ type ListOutput struct {
 func List(ctx context.Context, input *ListInput) (*ListOutput, error) {
 	db, err := psqlrscsrv.DefaultPsqlService.DB()
 	if err != nil {
-		return nil, errors.Wrap(err, errors.Code("db-available"), errors.Module("{{.Table}}_service"))
+		return nil, errors.Wrap(err, errors.Code("db-not-available"), errors.Module("{{.Table}}_service"))
 	}
 
 	var output ListOutput

--- a/cmd/athena/make/templates/psql/update_service.go
+++ b/cmd/athena/make/templates/psql/update_service.go
@@ -16,7 +16,7 @@ import (
 
 // UpdateInput holds input information for Update service
 type UpdateInput struct {
-	{{.Model}} *models.{{.Model}} `+"`"+`validate:"required"`+"`"+`
+	{{.Model}} *models.{{.Model}} `+"`"+`validate:"structonly,required"`+"`"+`
 	{{- range .Fields}}
 	{{formatFieldOptional .}}  `+"`"+`json:"{{formatFieldTag .}}" {{if hasValidation .}}validate:"omitempty,{{formatValidation .}}"{{end}}`+"`"+`
 	{{- end}}

--- a/cmd/athena/make/templates/psql/update_service.go
+++ b/cmd/athena/make/templates/psql/update_service.go
@@ -36,7 +36,7 @@ func Update(ctx context.Context, input *UpdateInput) (*UpdateOutput, error) {
 
 	db, err := psqlrscsrv.DefaultPsqlService.DB()
 	if err != nil {
-		return nil, errors.Wrap(err, errors.Code("db-available"), errors.Module("{{.Table}}_service"))
+		return nil, errors.Wrap(err, errors.Code("db-not-available"), errors.Module("{{.Table}}_service"))
 	}
 
 	store := models.New{{.Model}}Store(db)

--- a/command.go
+++ b/command.go
@@ -16,7 +16,7 @@ type CommandOptions struct {
 	BindAddress string
 	Wait        int
 	Hostname    string
-	isDryRun    bool
+	IsDryRun    bool
 }
 
 type commandBuilder struct {
@@ -82,12 +82,12 @@ func (b *commandBuilder) Build() cli.CmdInitializer {
 			EnvVar: "HOSTNAME",
 		})
 
-		cmd.BoolOptPtr(&options.isDryRun, "d dry-run", false, "Loads the configuration and check if the dependencies are working (such as database connections)")
+		cmd.BoolOptPtr(&options.IsDryRun, "d dry-run", false, "Loads the configuration and check if the dependencies are working (such as database connections)")
 
 		cmd.Before = func() {
 			os.Setenv("HOSTNAME", options.Hostname)
 
-			if options.isDryRun {
+			if options.IsDryRun {
 				rlog.Trace(1, "This is a dry run!")
 			}
 
@@ -106,7 +106,7 @@ func (b *commandBuilder) Build() cli.CmdInitializer {
 				}
 			}
 
-			if options.isDryRun {
+			if options.IsDryRun {
 				if b.serviceStarter != nil {
 					err := b.serviceStarter.Stop(false)
 					if err != nil {
@@ -115,7 +115,7 @@ func (b *commandBuilder) Build() cli.CmdInitializer {
 					}
 				}
 
-				if options.isDryRun {
+				if options.IsDryRun {
 					rlog.Trace(1, "Everything looks fine!")
 				}
 				os.Exit(0)

--- a/command.go
+++ b/command.go
@@ -1,0 +1,130 @@
+package athena
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	cli "github.com/jawher/mow.cli"
+	rscsrv "github.com/lab259/go-rscsrv"
+	"github.com/lab259/rlog/v2"
+)
+
+type CommandAction func(opt *CommandOptions)
+
+type CommandOptions struct {
+	BindAddress string
+	Wait        int
+	Hostname    string
+	isDryRun    bool
+}
+
+type commandBuilder struct {
+	wait           int
+	bindAddress    string
+	hostname       string
+	serviceStarter rscsrv.ServiceStarter
+	action         CommandAction
+}
+
+func NewCommand(action CommandAction) *commandBuilder {
+	hostname, _ := os.Hostname()
+	return &commandBuilder{
+		action:      action,
+		bindAddress: "127.0.0.1:3000",
+		wait:        0,
+		hostname:    hostname,
+	}
+}
+
+func (b *commandBuilder) ServiceStarter(serviceStarter rscsrv.ServiceStarter) *commandBuilder {
+	b.serviceStarter = serviceStarter
+	return b
+}
+
+func (b *commandBuilder) BindAddress(bindAddress string) *commandBuilder {
+	b.bindAddress = bindAddress
+	return b
+}
+
+func (b *commandBuilder) Wait(wait int) *commandBuilder {
+	b.wait = wait
+	return b
+}
+
+func (b *commandBuilder) Hostname(hostname string) *commandBuilder {
+	b.hostname = hostname
+	return b
+}
+
+func (b *commandBuilder) Build() cli.CmdInitializer {
+	return cli.CmdInitializer(func(cmd *cli.Cmd) {
+		var options CommandOptions
+
+		cmd.StringPtr(&options.BindAddress, cli.StringOpt{
+			Name:   "B bind-address",
+			Value:  b.bindAddress,
+			Desc:   "The bind address will be used on the HTTP server",
+			EnvVar: "BIND_ADDR",
+		})
+
+		cmd.IntPtr(&options.Wait, cli.IntOpt{
+			Name:   "w wait",
+			Value:  b.wait,
+			Desc:   "Delay in seconds before the initialization",
+			EnvVar: "WAIT",
+		})
+
+		cmd.StringPtr(&options.Hostname, cli.StringOpt{
+			Name:   "H hostname",
+			Value:  b.hostname,
+			Desc:   "The name of the station running the app instance",
+			EnvVar: "HOSTNAME",
+		})
+
+		cmd.BoolOptPtr(&options.isDryRun, "d dry-run", false, "Loads the configuration and check if the dependencies are working (such as database connections)")
+
+		cmd.Before = func() {
+			os.Setenv("HOSTNAME", options.Hostname)
+
+			if options.isDryRun {
+				rlog.Trace(1, "This is a dry run!")
+			}
+
+			if options.Wait > 0 {
+				rlog.Infof("  Waiting %d seconds before continue ...", options.Wait)
+				time.Sleep(time.Duration(options.Wait) * time.Second)
+				rlog.Info(fmt.Sprintf("    > Waiting %s", "DONE"))
+			}
+
+			if b.serviceStarter != nil {
+				err := b.serviceStarter.Start()
+				if err != nil {
+					b.serviceStarter.Stop(true)
+					rlog.Critical(err)
+					os.Exit(2)
+				}
+			}
+
+			if options.isDryRun {
+				if b.serviceStarter != nil {
+					err := b.serviceStarter.Stop(false)
+					if err != nil {
+						rlog.Critical(err)
+						os.Exit(2)
+					}
+				}
+
+				if options.isDryRun {
+					rlog.Trace(1, "Everything looks fine!")
+				}
+				os.Exit(0)
+			}
+		}
+
+		cmd.Action = func() {
+			b.action(&options)
+		}
+	})
+
+}

--- a/examples/multiapp/main.go
+++ b/examples/multiapp/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lab259/athena"
+)
+
+func main() {
+	cli, opt := athena.NewCLI("multiapp", `Multiapp Example`).
+		Version("v0.1.0", "da39a3ee5e6b4b0d3255bfef95601890afd80709").
+		Simple().
+		Build()
+
+	cli.Before = func() {
+		fmt.Printf("Version: %s (%s)\nEnvironment: %s\n\n", opt.Version, opt.Build, opt.Environment)
+	}
+
+	cli.Command("app", "REST API Server", athena.NewCommand(func(opt *athena.CommandOptions) {
+		fmt.Println("app server listening to " + opt.BindAddress)
+	}).Build())
+
+	cli.Command("graphql", "GraphQL Server", athena.NewCommand(func(opt *athena.CommandOptions) {
+		fmt.Println("graphql server listening to " + opt.BindAddress)
+	}).Build())
+
+	cli.Run(os.Args)
+}


### PR DESCRIPTION
### :sparkles: Enhancements

* Add ability to bootstrap commands for CLI (+ example)

### :bug: Bugs

* Set environment to `TEST` when starting NewPsqlTestService (if `ENV` is empty)

---

Resolves #5
